### PR TITLE
fix lint errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=120


### PR DESCRIPTION
add setup.cfg (copied from layer-apache-spark) to fix line-too-long lint errors
